### PR TITLE
Make sure generic error doesn't freeze prompt

### DIFF
--- a/examples/prompt/main.go
+++ b/examples/prompt/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/manifoldco/promptui"
+)
+
+func main() {
+	validate := func(input string) error {
+		_, err := strconv.ParseFloat(input, 64)
+		return err
+	}
+
+	prompt := promptui.Prompt{
+		Label:    "Number",
+		Validate: validate,
+	}
+
+	result, err := prompt.Run()
+
+	if err != nil {
+		fmt.Printf("Prompt failed %v\n", err)
+		return
+	}
+
+	fmt.Printf("You choose %q\n", result)
+}

--- a/prompt.go
+++ b/prompt.go
@@ -131,7 +131,6 @@ func (p *Prompt) Run() (string, error) {
 			if _, ok := err.(*ValidationError); ok {
 				state = IconBad
 			} else {
-				rl.Close()
 				return nil, 0, false
 			}
 		} else {


### PR DESCRIPTION
Before an error that was not a `ValidationError` was freezing the terminal.

Now it should just output the error string:
```
$ go run examples/prompt/main.go
Prompt failed strconv.ParseFloat: parsing "aa": invalid syntax
```