### PR TITLE
Fix max length for list

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -127,9 +127,9 @@ func (l *List) Selected() interface{} {
 	return l.items[l.cursor]
 }
 
-// Display returns a slice equal to the size of the list with the current
-// visible items.
-func (l *List) Display() []interface{} {
+// Items returns a slice equal to the size of the list with the current visible
+// items.
+func (l *List) Items() []interface{} {
 	var result []interface{}
 	max := len(l.items)
 	end := l.start + l.size

--- a/list/list.go
+++ b/list/list.go
@@ -131,7 +131,12 @@ func (l *List) Selected() interface{} {
 // visible items.
 func (l *List) Display() []interface{} {
 	var result []interface{}
+	max := len(l.items)
 	end := l.start + l.size
+
+	if end > max {
+		end = max
+	}
 
 	for i := l.start; i < end; i++ {
 		result = append(result, l.items[i])

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -49,7 +49,7 @@ func TestListMovement(t *testing.T) {
 				t.Fatalf("unknown move %q", tc.move)
 			}
 
-			got := castList(l.Display())
+			got := castList(l.Items())
 
 			if !reflect.DeepEqual(tc.expect, got) {
 				t.Errorf("expected %q, got %q", tc.expect, got)

--- a/select.go
+++ b/select.go
@@ -151,7 +151,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 
 		active := s.list.Selected()
 
-		display := s.list.Display()
+		display := s.list.Items()
 		last := len(display) - 1
 
 		for i, item := range display {


### PR DESCRIPTION
Ported fix from `search` branch. If the number of items was smaller than the size of the list, it was crashing on display.

Renamed method for clarity since we are not actually displaying anything.