### PR TITLE
Fix first line being erased when output increased

### DIFF
--- a/screenbuf/screenbuf.go
+++ b/screenbuf/screenbuf.go
@@ -43,6 +43,10 @@ func (s *ScreenBuf) Reset() {
 // the top. Lines with \r or \n will fail since they can interfere with the
 // terminal ability to move between lines.
 func (s *ScreenBuf) Write(b []byte) (int, error) {
+	if bytes.ContainsAny(b, "\r\n") {
+		return 0, fmt.Errorf("%q should not contain either \\r or \\n", b)
+	}
+
 	if s.reset {
 		for i := 0; i < s.height; i++ {
 			_, err := s.buf.Write(moveUp)
@@ -89,10 +93,11 @@ func (s *ScreenBuf) Write(b []byte) (int, error) {
 		s.cursor++
 		return n, nil
 	default:
-		return 0, fmt.Errorf("Invalid write cursor position (%d) exceeded line height: %d, cursor: %d", s.cursor, s.height)
+		return 0, fmt.Errorf("Invalid write cursor position (%d) exceeded line height: %d", s.cursor, s.height)
 	}
 }
 
+// Flush writes any buffered data to the underlying io.Writer.
 func (s *ScreenBuf) Flush() error {
 	for i := s.cursor; i < s.height; i++ {
 		if i < s.height {
@@ -130,12 +135,4 @@ func (s *ScreenBuf) Flush() error {
 // Check ScreenBuf.Write() for a detailed explanation of the function behaviour.
 func (s *ScreenBuf) WriteString(str string) (int, error) {
 	return s.Write([]byte(str))
-}
-
-// WriteTo writes data to w until the buffer is drained or an error occurs. The
-// return value n is the number of bytes written; it always fits into an int,
-// but it is int64 to match the io.WriterTo interface. Any error encountered
-// during the write is also returned.
-func (s *ScreenBuf) WriteTo(w io.Writer) (int64, error) {
-	return s.buf.WriteTo(w)
 }

--- a/screenbuf/screenbuf.go
+++ b/screenbuf/screenbuf.go
@@ -18,16 +18,17 @@ var (
 // clears and, moves up or down lines as needed to write the output to the
 // terminal using ANSI escape codes.
 type ScreenBuf struct {
+	w      io.Writer
 	buf    *bytes.Buffer
-	lines  [][]byte
 	reset  bool
 	flush  bool
 	cursor int
+	height int
 }
 
 // New creates and initializes a new ScreenBuf.
-func New() *ScreenBuf {
-	return &ScreenBuf{buf: &bytes.Buffer{}}
+func New(w io.Writer) *ScreenBuf {
+	return &ScreenBuf{buf: &bytes.Buffer{}, w: w}
 }
 
 // Reset truncates the underlining buffer and marks all its previous lines to be
@@ -42,35 +43,87 @@ func (s *ScreenBuf) Reset() {
 // the top. Lines with \r or \n will fail since they can interfere with the
 // terminal ability to move between lines.
 func (s *ScreenBuf) Write(b []byte) (int, error) {
-	if bytes.ContainsAny(b, "\r\n") {
-		return 0, fmt.Errorf("%q should not contain either \\r or \\n", b)
-	}
-
 	if s.reset {
-		for i := 1; i < len(s.lines); i++ {
-			_, err := s.buf.Write(clearLine)
+		for i := 0; i < s.height; i++ {
+			_, err := s.buf.Write(moveUp)
 			if err != nil {
 				return 0, err
 			}
-			_, err = s.buf.Write(moveUp)
+			_, err = s.buf.Write(clearLine)
 			if err != nil {
 				return 0, err
 			}
 		}
 		s.cursor = 0
-		s.lines = nil
+		s.height = 0
 		s.reset = false
 	}
 
-	if len(s.lines) <= s.cursor {
-		s.lines = append(s.lines, b)
-	} else {
-		s.lines[s.cursor] = b
+	switch {
+	case s.cursor == s.height:
+		n, err := s.buf.Write(clearLine)
+		if err != nil {
+			return n, err
+		}
+		line := append(b, []byte("\n")...)
+		n, err = s.buf.Write(line)
+		if err != nil {
+			return n, err
+		}
+		s.height++
+		s.cursor++
+		return n, nil
+	case s.cursor < s.height:
+		n, err := s.buf.Write(clearLine)
+		if err != nil {
+			return n, err
+		}
+		n, err = s.buf.Write(b)
+		if err != nil {
+			return n, err
+		}
+		n, err = s.buf.Write(moveDown)
+		if err != nil {
+			return n, err
+		}
+		s.cursor++
+		return n, nil
+	default:
+		return 0, fmt.Errorf("Invalid write cursor position (%d) exceeded line height: %d, cursor: %d", s.cursor, s.height)
+	}
+}
+
+func (s *ScreenBuf) Flush() error {
+	for i := s.cursor; i < s.height; i++ {
+		if i < s.height {
+			_, err := s.buf.Write(clearLine)
+			if err != nil {
+				return err
+			}
+		}
+		_, err := s.buf.Write(moveDown)
+		if err != nil {
+			return err
+		}
 	}
 
-	s.cursor++
+	_, err := s.buf.WriteTo(s.w)
+	if err != nil {
+		return err
+	}
 
-	return len(b), nil
+	s.buf.Reset()
+
+	for i := 0; i < s.height; i++ {
+		_, err := s.buf.Write(moveUp)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.cursor = 0
+
+	return nil
 }
 
 // WriteString is a convenient function to write a new line passing a string.
@@ -84,45 +137,5 @@ func (s *ScreenBuf) WriteString(str string) (int, error) {
 // but it is int64 to match the io.WriterTo interface. Any error encountered
 // during the write is also returned.
 func (s *ScreenBuf) WriteTo(w io.Writer) (int64, error) {
-	if s.flush {
-		for range s.lines {
-			_, err := s.buf.Write(moveUp)
-			if err != nil {
-				return 0, err
-			}
-		}
-	}
-
-	for i, line := range s.lines {
-		if s.flush {
-			_, err := s.buf.Write(clearLine)
-			if err != nil {
-				return 0, err
-			}
-
-			if i < s.cursor {
-				_, err = s.buf.Write(line)
-				if err != nil {
-					return 0, err
-				}
-			}
-
-			_, err = s.buf.Write(moveDown)
-			if err != nil {
-				return 0, err
-			}
-		} else {
-			l := append(line, []byte("\n")...)
-
-			_, err := s.buf.Write(l)
-			if err != nil {
-				return 0, err
-			}
-		}
-	}
-
-	s.flush = true
-	s.cursor = 0
-
 	return s.buf.WriteTo(w)
 }

--- a/screenbuf/screenbuf_test.go
+++ b/screenbuf/screenbuf_test.go
@@ -11,111 +11,109 @@ func TestScreen(t *testing.T) {
 	moveUp = []byte("\\u")
 	moveDown = []byte("\\d")
 
-	s := New()
+	var buf bytes.Buffer
+	s := New(&buf)
 
-	t.Run("initial flush", func(t *testing.T) {
-		s.Write([]byte("Hello Darkness,"))
-		s.Write([]byte("My Old Friend"))
-		s.Write([]byte("I've come to talk with you again"))
+	tcs := []struct {
+		scenario string
+		lines    []string
+		expect   string
+		cursor   int
+		height   int
+		flush    bool
+		reset    bool
+	}{
+		{
+			scenario: "initial write",
+			lines:    []string{"Line One"},
+			expect:   "\\cLine One\n",
+			cursor:   1,
+			height:   1,
+		},
+		{
+			scenario: "write of with same number of lines",
+			lines:    []string{"Line One"},
+			expect:   "\\u\\cLine One\\d",
+			cursor:   1,
+			height:   1,
+		},
+		{
+			scenario: "write of with more lines",
+			lines:    []string{"Line One", "Line Two"},
+			expect:   "\\u\\cLine One\\d\\cLine Two\n",
+			cursor:   2,
+			height:   2,
+		},
+		{
+			scenario: "write of with fewer lines",
+			lines:    []string{"line One"},
+			expect:   "\\u\\u\\cline One\\d\\c\\d",
+			cursor:   1,
+			height:   2,
+		},
+		{
+			scenario: "write of way more lines",
+			lines:    []string{"line one", "line two", "line three", "line four", "line five"},
+			expect:   "\\u\\u\\cline one\\d\\cline two\\d\\cline three\n\\cline four\n\\cline five\n",
+			cursor:   5,
+			height:   5,
+		},
+		{
+			scenario: "write of way less lines",
+			lines:    []string{"line one", "line two"},
+			expect:   "\\u\\u\\u\\u\\u\\cline one\\d\\cline two\\d\\c\\d\\c\\d\\c\\d",
+			cursor:   2,
+			height:   5,
+		},
+		{
+			scenario: "write of way more lines",
+			lines:    []string{"line one", "line two", "line three", "line four", "line five"},
+			expect:   "\\u\\u\\u\\u\\u\\cline one\\d\\cline two\\d\\cline three\\d\\cline four\\d\\cline five\\d",
+			cursor:   5,
+			height:   5,
+		},
+		{
+			scenario: "reset and write",
+			lines:    []string{"line one", "line two"},
+			expect:   "\\u\\c\\u\\c\\u\\c\\u\\c\\u\\c\\cline one\n\\cline two\n",
+			cursor:   2,
+			height:   2,
+			reset:    true,
+		},
+	}
 
-		var buf bytes.Buffer
+	for _, tc := range tcs {
+		t.Run(tc.scenario, func(t *testing.T) {
+			buf.Reset()
+			if tc.reset {
+				s.Reset()
+			}
 
-		_, err := s.WriteTo(&buf)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
+			for _, line := range tc.lines {
+				_, err := s.WriteString(line)
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+			}
 
-		expect := `Hello Darkness,
-My Old Friend
-I've come to talk with you again
-`
+			if tc.cursor != s.cursor {
+				t.Errorf("expected cursor %d, got %d", tc.cursor, s.cursor)
+			}
 
-		got := buf.String()
+			err := s.Flush()
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
 
-		if expect != got {
-			t.Errorf("expected %s, got %s", expect, got)
-		}
-	})
+			got := buf.String()
 
-	t.Run("flush with same amount of lines", func(t *testing.T) {
-		s.Write([]byte("Because a vision softly creeping"))
-		s.Write([]byte("Left it's seeds while I was sleeping"))
-		s.Write([]byte("And the vision that was planted"))
+			if tc.expect != got {
+				t.Errorf("expected %q, got %q", tc.expect, got)
+			}
 
-		var buf bytes.Buffer
-		_, err := s.WriteTo(&buf)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		expect := `\u\u\u\cBecause a vision softly creeping\d\cLeft it's seeds while I was sleeping\d\cAnd the vision that was planted\d`
-
-		got := buf.String()
-
-		if expect != got {
-			t.Errorf("expected:\n%s\ngot:\n%s", expect, got)
-		}
-	})
-
-	t.Run("flush with less lines", func(t *testing.T) {
-		s.Write([]byte("In my brain still remains"))
-		s.Write([]byte("Within the sound of silence"))
-
-		var buf bytes.Buffer
-		_, err := s.WriteTo(&buf)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		expect := `\u\u\u\cIn my brain still remains\d\cWithin the sound of silence\d\c\d`
-
-		got := buf.String()
-
-		if expect != got {
-			t.Errorf("expected:\n%s\ngot:\n%s", expect, got)
-		}
-	})
-
-	t.Run("flush with more lines", func(t *testing.T) {
-		s.Write([]byte("In restless dreams I walked alone"))
-		s.Write([]byte("Narrow streets of cobblestone"))
-		s.Write([]byte("'Neath the halo of a street lamp"))
-		s.Write([]byte("I turned my collar to the cold and damp"))
-		s.Write([]byte("When my eyes were stabbed by the flash of"))
-		s.Write([]byte("A neon light that split the night"))
-		s.Write([]byte("And touched the sound of silence"))
-
-		var buf bytes.Buffer
-		_, err := s.WriteTo(&buf)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		expect := `\u\u\u\u\u\u\u\cIn restless dreams I walked alone\d\cNarrow streets of cobblestone\d\c'Neath the halo of a street lamp\d\cI turned my collar to the cold and damp\d\cWhen my eyes were stabbed by the flash of\d\cA neon light that split the night\d\cAnd touched the sound of silence\d`
-
-		got := buf.String()
-
-		if expect != got {
-			t.Errorf("expected:\n%s\ngot:\n%s", expect, got)
-		}
-	})
-
-	t.Run("reset with fewer lines", func(t *testing.T) {
-		s.Reset()
-		s.Write([]byte("The Sound of Silence"))
-
-		var buf bytes.Buffer
-		_, err := s.WriteTo(&buf)
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		expect := `\c\u\c\u\c\u\c\u\c\u\c\u\u\cThe Sound of Silence\d`
-
-		got := buf.String()
-
-		if expect != got {
-			t.Errorf("expected:\n%s\ngot:\n%s", expect, got)
-		}
-	})
+			if tc.height != s.height {
+				t.Errorf("expected height %d, got %d", tc.height, s.height)
+			}
+		})
+	}
 }

--- a/select.go
+++ b/select.go
@@ -116,7 +116,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 	}
 
 	rl.Write([]byte(hideCursor))
-	sb := screenbuf.New()
+	sb := screenbuf.New(rl)
 
 	rl.Operation.ExitVimInsertMode() // Never use insert mode for selects
 
@@ -186,8 +186,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 			sb.Write(d)
 		}
 
-		sb.WriteTo(rl)
-		rl.Refresh()
+		sb.Flush()
 
 		return nil, 0, true
 	})
@@ -214,7 +213,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 
 	sb.Reset()
 	sb.Write(output)
-	sb.WriteTo(rl)
+	sb.Flush()
 
 	rl.Write([]byte(showCursor))
 	rl.Close()


### PR DESCRIPTION
Simplified screenbuf code and tests in the process.

There still an issue when the screen is small and line wrapping occurs. I was trying to use ansi codes to erase part of the screen, so we wouldn't need to keep track of lines written, but it didn't quite work.