### PR TITLE
Compare active items by index

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -30,7 +30,8 @@ func New(items interface{}, size int) (*List, error) {
 
 	slice := reflect.ValueOf(items)
 	for i := 0; i < slice.Len(); i++ {
-		l.items = append(l.items, slice.Index(i).Interface())
+		item := slice.Index(i).Interface()
+		l.items = append(l.items, item)
 	}
 
 	return l, nil
@@ -122,14 +123,9 @@ func (l *List) Index() int {
 	return l.cursor
 }
 
-// Selected returns the item currently selected.
-func (l *List) Selected() interface{} {
-	return l.items[l.cursor]
-}
-
 // Items returns a slice equal to the size of the list with the current visible
-// items.
-func (l *List) Items() []interface{} {
+// items and the index of the active item in this list.
+func (l *List) Items() ([]interface{}, int) {
 	var result []interface{}
 	max := len(l.items)
 	end := l.start + l.size
@@ -138,9 +134,15 @@ func (l *List) Items() []interface{} {
 		end = max
 	}
 
-	for i := l.start; i < end; i++ {
+	active := 0
+
+	for i, j := l.start, 0; i < end; i, j = i+1, j+1 {
+		if l.cursor == i {
+			active = j
+		}
+
 		result = append(result, l.items[i])
 	}
 
-	return result
+	return result, active
 }

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -6,6 +6,29 @@ import (
 	"testing"
 )
 
+func TestListNew(t *testing.T) {
+	t.Run("when items a slice nil", func(t *testing.T) {
+		_, err := New([]int{1, 2, 3}, 3)
+		if err != nil {
+			t.Errorf("Expected no errors, error %v", err)
+		}
+	})
+
+	t.Run("when items is nil", func(t *testing.T) {
+		_, err := New(nil, 3)
+		if err == nil {
+			t.Errorf("Expected error got none")
+		}
+	})
+
+	t.Run("when items is not a slice", func(t *testing.T) {
+		_, err := New("1,2,3", 3)
+		if err == nil {
+			t.Errorf("Expected error got none")
+		}
+	})
+}
+
 func TestListMovement(t *testing.T) {
 	letters := []rune{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'}
 
@@ -49,13 +72,15 @@ func TestListMovement(t *testing.T) {
 				t.Fatalf("unknown move %q", tc.move)
 			}
 
-			got := castList(l.Items())
+			list, idx := l.Items()
+
+			got := castList(list)
 
 			if !reflect.DeepEqual(tc.expect, got) {
 				t.Errorf("expected %q, got %q", tc.expect, got)
 			}
 
-			selected := l.Selected()
+			selected := list[idx]
 
 			if tc.selected != selected {
 				t.Errorf("expected selected to be %q, got %q", tc.selected, selected)

--- a/select.go
+++ b/select.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"text/template"
 
 	"github.com/chzyer/readline"
@@ -149,12 +148,10 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 		label := renderBytes(s.Templates.label, s.Label)
 		sb.Write(label)
 
-		active := s.list.Selected()
+		items, idx := s.list.Items()
+		last := len(items) - 1
 
-		display := s.list.Items()
-		last := len(display) - 1
-
-		for i, item := range display {
+		for i, item := range items {
 			page := " "
 
 			switch i {
@@ -172,7 +169,7 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 
 			output := []byte(page + " ")
 
-			if item == active {
+			if i == idx {
 				output = append(output, renderBytes(s.Templates.active, item)...)
 			} else {
 				output = append(output, renderBytes(s.Templates.inactive, item)...)
@@ -180,6 +177,8 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 
 			sb.Write(output)
 		}
+
+		active := items[idx]
 
 		details := s.detailsOutput(active)
 		for _, d := range details {
@@ -207,7 +206,8 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 		return 0, "", err
 	}
 
-	item := s.list.Selected()
+	items, idx := s.list.Items()
+	item := items[idx]
 
 	output := renderBytes(s.Templates.selected, item)
 
@@ -222,10 +222,6 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 }
 
 func (s *Select) prepareTemplates() error {
-	if s.Items == nil || reflect.TypeOf(s.Items).Kind() != reflect.Slice {
-		return fmt.Errorf("Items %v is not a slice", s.Items)
-	}
-
 	tpls := s.Templates
 	if tpls == nil {
 		tpls = &SelectTemplates{}

--- a/select_test.go
+++ b/select_test.go
@@ -129,26 +129,6 @@ Description: {{.Description}}`,
 		}
 	})
 
-	t.Run("when items is nil", func(t *testing.T) {
-		s := Select{}
-
-		err := s.prepareTemplates()
-		if err == nil {
-			t.Fatalf("Expected error got none")
-		}
-	})
-
-	t.Run("when items is not a slice", func(t *testing.T) {
-		s := Select{
-			Items: "1,2,3",
-		}
-
-		err := s.prepareTemplates()
-		if err == nil {
-			t.Fatalf("Expected error got none")
-		}
-	})
-
 	t.Run("when a template render fails", func(t *testing.T) {
 		templates := &SelectTemplates{
 			Label: "{{ .InvalidName }}",


### PR DESCRIPTION
Interface comparison can fail if the value contains types that cannot be compared, ie: slices.

`List.Items()` now return both a slice of items and the index of the current active item.