### PR TITLE
Remove prompt success/failure funcs

### DIFF
--- a/promptui.go
+++ b/promptui.go
@@ -16,13 +16,3 @@ var ErrAbort = errors.New("")
 // ValidateFunc validates the given input. It should return a ValidationError
 // if the input is not valid.
 type ValidateFunc func(string) error
-
-// SuccessfulValue returns a value as if it were entered via prompt, valid
-func SuccessfulValue(label, value string) string {
-	return IconGood + " " + label + ": " + faint(value)
-}
-
-// FailedValue returns a value as if it were entered via prompt, invalid
-func FailedValue(label, value string) string {
-	return IconBad + " " + label + ": " + faint(value)
-}

--- a/styles.go
+++ b/styles.go
@@ -2,10 +2,6 @@
 
 package promptui
 
-var (
-	faint = Styler(FGFaint)
-)
-
 // Icons used for displaying prompts or status
 var (
 	IconInitial = Styler(FGBlue)("?")

--- a/styles_windows.go
+++ b/styles_windows.go
@@ -1,9 +1,5 @@
 package promptui
 
-var (
-	faint = Styler(FGFaint)
-)
-
 // Icons used for displaying prompts or status
 var (
 	IconInitial = Styler(FGBlue)("?")


### PR DESCRIPTION
Now that we have custom templates, these functions don't really make sense. The logic to handle flags that bypass the select has been moved to the cli: https://github.com/manifoldco/manifold-cli/pull/163/commits/408e7d26c12f3db0d3c6d4aac88b3d3915457c8c