### PR TITLE
Select: allow j/k for selection.

### DIFF
--- a/select.go
+++ b/select.go
@@ -120,24 +120,12 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 	rl.Operation.ExitVimInsertMode() // Never use insert mode for selects
 
 	c.SetListener(func(line []rune, pos int, key rune) ([]rune, int, bool) {
-		if rl.Operation.IsEnableVimMode() {
-			rl.Operation.ExitVimInsertMode()
-			// Remap j and k for down/up selections immediately after an
-			// `i` press
-			switch key {
-			case 'j':
-				key = readline.CharNext
-			case 'k':
-				key = readline.CharPrev
-			}
-		}
-
 		switch key {
 		case readline.CharEnter:
 			return nil, 0, true
-		case readline.CharNext:
+		case readline.CharNext, 'j':
 			s.list.Next()
-		case readline.CharPrev:
+		case readline.CharPrev, 'k':
 			s.list.Prev()
 		case ' ': // space press
 			s.list.PageDown()


### PR DESCRIPTION
We never allow VimInsertMode for selection, but we can allow just j/k to
be used for line selection.

@luizbranco I'm not sure if there's specific reasons to not allow Vim
insert mode? I'd prefer it to be based on that to be honest, but wanted
to check in first if there's a specific reason.

On line 120, we always exit the vim insert mode, so the conditional 
block would never be triggered.