### PR TITLE
Fix pagination panic

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -91,9 +91,12 @@ func (l *List) PageDown() {
 	start := l.start + l.size
 	max := len(l.items) - l.size
 
-	if start > max {
+	switch {
+	case len(l.items) < l.size:
+		l.start = 0
+	case start > max:
 		l.start = max
-	} else {
+	default:
 		l.start = start
 	}
 

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -89,6 +89,26 @@ func TestListMovement(t *testing.T) {
 	}
 }
 
+func TestListPageDown(t *testing.T) {
+	t.Run("when list has fewer items than page size", func(t *testing.T) {
+		letters := []rune{'a', 'b'}
+		l, err := New(letters, 4)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		l.PageDown()
+		list, idx := l.Items()
+
+		expected := 'b'
+		selected := list[idx]
+
+		if selected != expected {
+			t.Errorf("expected selected to be %q, got %q", selected, selected)
+		}
+	})
+}
+
 func castList(list []interface{}) []rune {
 	result := make([]rune, len(list))
 	for i, l := range list {

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -104,7 +104,7 @@ func TestListPageDown(t *testing.T) {
 		selected := list[idx]
 
 		if selected != expected {
-			t.Errorf("expected selected to be %q, got %q", selected, selected)
+			t.Errorf("expected selected to be %q, got %q", expected, selected)
 		}
 	})
 }


### PR DESCRIPTION
If you have a select list with say, 2 items, and hit space it panics.
It's trying to access items out of range.

Closes: https://github.com/manifoldco/engineering/issues/3286