### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ func main() {
 		return
 	}
 
-	fmt.Printf("You choose %q\n", result)
+	fmt.Printf("You chose %q\n", result)
 }
 ```
 


### PR DESCRIPTION
What
===
Change `You choose` to `You chose` in the prompt usage example.

Why
===
The statement is describing an action using present tense (choose), but the action of choice has already taken place and therefore it should be in past tense (chose).