### PR TITLE
prompt.go: Adopt io.ReadCloser and io.WriteCloser

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -35,8 +35,8 @@ type Prompt struct {
 	IsConfirm bool
 	IsVimMode bool
 
-	stdin  io.Reader
-	stdout io.Writer
+	stdin  io.ReadCloser
+	stdout io.WriteCloser
 }
 
 // PromptTemplates allow a prompt to be customized following stdlib


### PR DESCRIPTION
As mentioned in #46, there is an error when I run `go get github.com/manifoldco/promptui`:

```
github.com/manifoldco/promptui/prompt.go:88:11: cannot use p.stdin (type io.Reader) as type io.ReadCloser in assignment:
io.Reader does not implement io.ReadCloser (missing Close method)
```

This commit simply fixes it(fixes #46). But I'm not sure this will cause side-effects since I haven't read other codes yet.