### PR TITLE
fix typo in Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,5 +12,5 @@ required=[
   branch = "master"
 
 [[constraint]]
-  name = "github.com/juju/master"
+  name = "github.com/juju/ansiterm"
   branch = "master"


### PR DESCRIPTION
In fact, I don't know if it's actually a typo since I haven't used `dep` tool, but it definitely looks strange. So shouldn't it be `github.com/juju/ansiterm` instead of `github.com/juju/master` in this [line](https://github.com/manifoldco/promptui/blob/1b661b0e9930aa5739fc44821cdf52d47888d7c0/Gopkg.toml#L15)?