### PR TITLE
Change description for navigation keys for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Improved documentation for GoDoc
+- Navigation keys information for Windows
 
 ### Fixed
 

--- a/keycodes.go
+++ b/keycodes.go
@@ -14,14 +14,18 @@ var (
 	KeyBackspace rune = readline.CharBackspace
 
 	// KeyPrev is the default key to go up during selection.
-	KeyPrev rune = readline.CharPrev
+	KeyPrev        rune = readline.CharPrev
+	KeyPrevDisplay      = "↑"
 
 	// KeyNext is the default key to go down during selection.
-	KeyNext rune = readline.CharNext
+	KeyNext        rune = readline.CharNext
+	KeyNextDisplay      = "↓"
 
 	// KeyBackward is the default key to page up during selection.
-	KeyBackward rune = readline.CharBackward
+	KeyBackward        rune = readline.CharBackward
+	KeyBackwardDisplay      = "←"
 
 	// KeyForward is the default key to page down during selection.
-	KeyForward rune = readline.CharForward
+	KeyForward        rune = readline.CharForward
+	KeyForwardDisplay      = "→"
 )

--- a/keycodes_windows.go
+++ b/keycodes_windows.go
@@ -12,14 +12,18 @@ var (
 	// FIXME: keys below are not triggered by readline, not working on Windows
 
 	// KeyPrev is the default key to go up during selection inside a command line prompt.
-	KeyPrev rune = 38
+	KeyPrev        rune = 38
+	KeyPrevDisplay      = "k"
 
 	// KeyNext is the default key to go down during selection inside a command line prompt.
-	KeyNext rune = 40
+	KeyNext        rune = 40
+	KeyNextDisplay      = "j"
 
 	// KeyBackward is the default key to page up during selection inside a command line prompt.
-	KeyBackward rune = 37
+	KeyBackward        rune = 37
+	KeyBackwardDisplay      = "h"
 
 	// KeyForward is the default key to page down during selection inside a command line prompt.
-	KeyForward rune = 39
+	KeyForward        rune = 39
+	KeyForwardDisplay      = "l"
 )

--- a/select.go
+++ b/select.go
@@ -526,10 +526,10 @@ func (s *Select) setKeys() {
 		return
 	}
 	s.Keys = &SelectKeys{
-		Prev:     Key{Code: KeyPrev, Display: "↑"},
-		Next:     Key{Code: KeyNext, Display: "↓"},
-		PageUp:   Key{Code: KeyBackward, Display: "←"},
-		PageDown: Key{Code: KeyForward, Display: "→"},
+		Prev:     Key{Code: KeyPrev, Display: KeyPrevDisplay},
+		Next:     Key{Code: KeyNext, Display: KeyNextDisplay},
+		PageUp:   Key{Code: KeyBackward, Display: KeyBackwardDisplay},
+		PageDown: Key{Code: KeyForward, Display: KeyForwardDisplay},
 		Search:   Key{Code: '/', Display: "/"},
 	}
 }


### PR DESCRIPTION
Since arrows are currently not supported to navigate, it make sense to show vi-like navigation to Window users.