### PR TITLE
add Do func to execute after selection , with example.

### DIFF
--- a/_examples/select_func/main.go
+++ b/_examples/select_func/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/manifoldco/promptui"
+)
+
+type nextDay struct {
+	Name string
+	time.Time
+}
+
+func (n nextDay) String() string {
+	return fmt.Sprintf("Next %v : %v", n.Name, n.Format("2-January-2006"))
+}
+
+func main() {
+	prompt := promptui.Select{
+		Label: "Select Day",
+		Items: []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
+		Do: func(index int, l string) (interface{}, error) {
+			if l == "Saturday" {
+				return nil, fmt.Errorf("%v is example error", l)
+			}
+			addDays := 7
+			today := int(time.Now().Weekday())
+			if index > today {
+				addDays = index - today
+			} else if index < today {
+				addDays = 7 - today + index
+			}
+			return nextDay{l, time.Now().AddDate(0, 0, addDays)}, nil
+		},
+	}
+
+	nextdateFunc, err := prompt.Runfunc()
+
+	if err != nil {
+		fmt.Printf("Prompt failed %v\n", err)
+		return
+	}
+	nextday, err := nextdateFunc()
+	if err != nil {
+		fmt.Printf("func executation error: %v\n", err)
+		return
+	}
+	fmt.Println(nextday)
+}

--- a/select.go
+++ b/select.go
@@ -67,6 +67,8 @@ type Select struct {
 	label string
 
 	list *list.List
+
+	Do func(int, string) (interface{}, error)
 }
 
 // SelectKeys defines the available keys used by select mode to enable the user to move around the list
@@ -191,6 +193,15 @@ func (s *Select) Run() (int, string, error) {
 		return 0, "", err
 	}
 	return s.innerRun(0, ' ')
+}
+
+// Runfunc in addition to Run(), it return Do func(), error.
+func (s *Select) Runfunc() (func() (interface{}, error), error) {
+	if s.Do == nil {
+		return nil, fmt.Errorf("Do func not implemented")
+	}
+	index, label, err := s.Run()
+	return func() (interface{}, error) { return s.Do(index, label) }, err
 }
 
 func (s *Select) innerRun(starting int, top rune) (int, string, error) {


### PR DESCRIPTION
Give package user an ability to add `Do func()` in `Select{}` object to execute after selection.
- you can find simple example how to use, the example about get selected next weekday date.
- please feel free to ask for more update.