### PR TITLE
prompt: fix default success template, missing space

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -351,7 +351,7 @@ func (p *Prompt) prepareTemplates() error {
 	tpls.validation = tpl
 
 	if tpls.Success == "" {
-		tpls.Success = `{{ . | faint }}`
+		tpls.Success = fmt.Sprintf("{{ . | faint }}%s ", Styler(FGFaint)(":"))
 	}
 
 	tpl, err = template.New("").Funcs(tpls.FuncMap).Parse(tpls.Success)


### PR DESCRIPTION
Running the `prompt_default` example without the patch:

```
(prompt)
Username: foo
(after Enter pressed)
Usernamefoo
```

With patch

```
(prompt, no change)
Username: foo
(after Enter pressed)
Username: foo
```