### PR TITLE
Add hooks so that multiple calls to a select can maintain scroll and cursor position

### DIFF
--- a/list/list.go
+++ b/list/list.go
@@ -91,6 +91,43 @@ func (l *List) search(term string) {
 	l.scope = scope
 }
 
+// Start returns the current render start position of the list.
+func (l *List) Start() int {
+	return l.start
+}
+
+// SetStart sets the current scroll position. Values out of bounds will be
+// clamped.
+func (l *List) SetStart(i int) {
+	if i < 0 {
+		i = 0
+	}
+	if i > l.cursor {
+		l.start = l.cursor
+	} else {
+		l.start = i
+	}
+}
+
+// SetCursor sets the position of the cursor in the list. Values out of bounds
+// will be clamped.
+func (l *List) SetCursor(i int) {
+	max := len(l.scope) - 1
+	if i >= max {
+		i = max
+	}
+	if i < 0 {
+		i = 0
+	}
+	l.cursor = i
+
+	if l.start > l.cursor {
+		l.start = l.cursor
+	} else if l.start+l.size <= l.cursor {
+		l.start = l.cursor - l.size + 1
+	}
+}
+
 // Next moves the visible list forward one item. If the selected item is out of
 // view, the new select item becomes the first visible item. If the list is
 // already at the bottom, nothing happens.

--- a/select.go
+++ b/select.go
@@ -167,11 +167,21 @@ type SelectTemplates struct {
 	help     *template.Template
 }
 
-// Run executes the select list. Its displays the label and the list of items, asking the user to chose any
+// Run executes the select list. It displays the label and the list of items, asking the user to chose any
 // value within to list. Run will keep the prompt alive until it has been canceled from
 // the command prompt or it has received a valid value. It will return the value and an error if any
 // occurred during the select's execution.
 func (s *Select) Run() (int, string, error) {
+	return s.RunCursorAt(0, 0)
+}
+
+// RunCursorAt executes the select list, initializing the cursor to the given
+// position. Invalid cursor positions will be clamped to valid values.  It
+// displays the label and the list of items, asking the user to chose any value
+// within to list. Run will keep the prompt alive until it has been canceled
+// from the command prompt or it has received a valid value. It will return
+// the value and an error if any occurred during the select's execution.
+func (s *Select) RunCursorAt(cursorPos, scroll int) (int, string, error) {
 	if s.Size == 0 {
 		s.Size = 5
 	}
@@ -190,10 +200,10 @@ func (s *Select) Run() (int, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	return s.innerRun(0, ' ')
+	return s.innerRun(cursorPos, scroll, ' ')
 }
 
-func (s *Select) innerRun(starting int, top rune) (int, string, error) {
+func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) {
 	stdin := readline.NewCancelableStdin(os.Stdin)
 	c := &readline.Config{}
 	err := c.Init()
@@ -221,6 +231,8 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 	var searchInput []rune
 	canSearch := s.Searcher != nil
 	searchMode := s.StartInSearchMode
+	s.list.SetCursor(cursorPos)
+	s.list.SetStart(scroll)
 
 	c.SetListener(func(line []rune, pos int, key rune) ([]rune, int, bool) {
 		switch {
@@ -369,6 +381,11 @@ func (s *Select) innerRun(starting int, top rune) (int, string, error) {
 	return s.list.Index(), fmt.Sprintf("%v", item), err
 }
 
+// ScrollPosition returns the current scroll position.
+func (s *Select) ScrollPosition() int {
+	return s.list.Start()
+}
+
 func (s *Select) prepareTemplates() error {
 	tpls := s.Templates
 	if tpls == nil {
@@ -503,7 +520,7 @@ func (sa *SelectWithAdd) Run() (int, string, error) {
 			return 0, "", err
 		}
 
-		selected, value, err := s.innerRun(1, '+')
+		selected, value, err := s.innerRun(1, 0, '+')
 		if err != nil || selected != 0 {
 			return selected - 1, value, err
 		}


### PR DESCRIPTION
I have a small application where users can select an item in a list to trigger an action, and then it wants to immediately redisplay the same list with the cursor at the same position.  This PR adds the hooks needed to do this.

The API is a little awkward because callers must record the selected cursor position and the scroll position and then set them manually.  If this functionality is considered worthwhile, I could do more work to make the Select object itself store this information so it could be reused transparently.