### PR TITLE
add coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 vendor
-coverage.txt
+all-cover.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,9 @@ branches:
   - master
 
 install: make bootstrap
+
+script:
+  - make cover
+after_success:
+  # only report coverage for go-version 1.11
+  - if [[ $TRAVIS_GO_VERSION =~ ^1\.11 ]] ; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install: make bootstrap
 
 after_success:
   # only report coverage for go-version 1.11
-  - if [[ $TRAVIS_GO_VERSION =~ ^1\.11 ]] ; then bash <(curl -s https://codecov.io/bash); fi
+  - if [[ $TRAVIS_GO_VERSION =~ ^1\.11 ]] ; then bash <(curl -s https://codecov.io/bash) -f all-cover.txt; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ branches:
 
 install: make bootstrap
 
-script:
-  - make cover
 after_success:
   # only report coverage for go-version 1.11
   - if [[ $TRAVIS_GO_VERSION =~ ^1\.11 ]] ; then bash <(curl -s https://codecov.io/bash); fi

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LINTERS=$(shell grep "// lint" tools.go | awk '{gsub(/\"/, "", $$1); print $$1}'
 	gofmt \
 	vet
 
-ci: $(LINTERS) test
+ci: $(LINTERS) cover
 
 .PHONY: ci
 

--- a/Makefile
+++ b/Makefile
@@ -60,5 +60,8 @@ $(LINTERS): %: vendor/bin/gometalinter %-bin vendor
 	PATH=`pwd`/vendor/bin:$$PATH gometalinter --tests --disable-all --vendor \
 		--deadline=5m -s data --enable $@ ./...
 
+cover: vendor
+	@CGO_ENABLED=0 go test -v -coverprofile=coverage.txt -covermode=atomic $$(go list ./... | grep -v vendor | grep -v generated)
+
 .PHONY: $(LINTERS) test
 .PHONY: cover all-cover.txt


### PR DESCRIPTION
This PR adds coverage reporting to promptui.  Since promptui runs tests run for Go versions 1.9, 1.10, and 1.11 - I've configured it to only publish the report to codecov for 1.11.