### PR TITLE
add support for hiding selected text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.4.0] - 2019-02-19
+
+### Added
+
+- The text displayed when an item was successfully selected can be hidden
+
 ## [0.3.2] - 2018-11-26
 
 ### Added

--- a/screenbuf/screenbuf.go
+++ b/screenbuf/screenbuf.go
@@ -38,6 +38,24 @@ func (s *ScreenBuf) Reset() {
 	s.reset = true
 }
 
+// Clear clears all previous lines and the output starts from the top.
+func (s *ScreenBuf) Clear() error {
+	for i := 0; i < s.height; i++ {
+		_, err := s.buf.Write(moveUp)
+		if err != nil {
+			return err
+		}
+		_, err = s.buf.Write(clearLine)
+		if err != nil {
+			return err
+		}
+	}
+	s.cursor = 0
+	s.height = 0
+	s.reset = false
+	return nil
+}
+
 // Write writes a single line to the underlining buffer. If the ScreenBuf was
 // previously reset, all previous lines are cleared and the output starts from
 // the top. Lines with \r or \n will cause an error since they can interfere with the
@@ -48,19 +66,9 @@ func (s *ScreenBuf) Write(b []byte) (int, error) {
 	}
 
 	if s.reset {
-		for i := 0; i < s.height; i++ {
-			_, err := s.buf.Write(moveUp)
-			if err != nil {
-				return 0, err
-			}
-			_, err = s.buf.Write(clearLine)
-			if err != nil {
-				return 0, err
-			}
+		if err := s.Clear(); err != nil {
+			return 0, err
 		}
-		s.cursor = 0
-		s.height = 0
-		s.reset = false
 	}
 
 	switch {

--- a/screenbuf/screenbuf_test.go
+++ b/screenbuf/screenbuf_test.go
@@ -22,6 +22,7 @@ func TestScreen(t *testing.T) {
 		height   int
 		flush    bool
 		reset    bool
+		clear    bool
 	}{
 		{
 			scenario: "initial write",
@@ -80,6 +81,14 @@ func TestScreen(t *testing.T) {
 			height:   2,
 			reset:    true,
 		},
+		{
+			scenario: "clear all previous lines",
+			lines:    []string{"line one", "line two"},
+			expect:   "\\u\\u\\cline one\\d\\cline two\\d\\u\\c\\u\\c",
+			cursor:   0,
+			height:   0,
+			clear:    true,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -93,6 +102,12 @@ func TestScreen(t *testing.T) {
 				_, err := s.WriteString(line)
 				if err != nil {
 					t.Fatalf("expected no error, got %v", err)
+				}
+			}
+
+			if tc.clear {
+				if err := s.Clear(); err != nil {
+					t.Errorf("expected no error, got %d", err)
 				}
 			}
 

--- a/select.go
+++ b/select.go
@@ -380,9 +380,7 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 	item := items[idx]
 
 	if s.HideSelected {
-		sb.Reset()
-		sb.Clear()
-		sb.Flush()
+		clearScreen(sb)
 	} else {
 		sb.Reset()
 		sb.Write(render(s.Templates.selected, item))
@@ -621,4 +619,10 @@ func render(tpl *template.Template, data interface{}) []byte {
 		return []byte(fmt.Sprintf("%v", data))
 	}
 	return buf.Bytes()
+}
+
+func clearScreen(sb *screenbuf.ScreenBuf) {
+	sb.Reset()
+	sb.Clear()
+	sb.Flush()
 }

--- a/select.go
+++ b/select.go
@@ -48,6 +48,9 @@ type Select struct {
 	// HideHelp sets whether to hide help information.
 	HideHelp bool
 
+	// HideSelected sets whether to hide the text displayed after an item is successfully selected.
+	HideSelected bool
+
 	// Templates can be used to customize the select output. If nil is passed, the
 	// default templates are used. See the SelectTemplates docs for more info.
 	Templates *SelectTemplates
@@ -376,11 +379,16 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 	items, idx := s.list.Items()
 	item := items[idx]
 
-	output := render(s.Templates.selected, item)
+	if s.HideSelected {
+		sb.Reset()
+		sb.Clear()
+		sb.Flush()
+	} else {
+		sb.Reset()
+		sb.Write(render(s.Templates.selected, item))
+		sb.Flush()
+	}
 
-	sb.Reset()
-	sb.Write(output)
-	sb.Flush()
 	rl.Write([]byte(showCursor))
 	rl.Close()
 

--- a/select_test.go
+++ b/select_test.go
@@ -1,7 +1,10 @@
 package promptui
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/manifoldco/promptui/screenbuf"
 )
 
 func TestSelectTemplateRender(t *testing.T) {
@@ -147,4 +150,19 @@ Description: {{.Description}}`,
 			t.Errorf("Expected label to eq %q, got %q", exp, result)
 		}
 	})
+}
+
+func TestClearScreen(t *testing.T) {
+	var buf bytes.Buffer
+	sb := screenbuf.New(&buf)
+
+	sb.WriteString("test")
+	clearScreen(sb)
+
+	got := buf.String()
+	except := "\x1b[1A\x1b[2K\r"
+
+	if except != got {
+		t.Errorf("expected %q, got %q", except, got)
+	}
 }


### PR DESCRIPTION
Sometimes the text displayed after an item is successfully selected is a bit redundant, and hiding it might make the subsequent output look more comfortable.