### PR TITLE
Fix readline error handling by reverting err shadowing bug

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -57,6 +57,8 @@ var ResetCode = fmt.Sprintf("%s%dm", esc, reset)
 const (
 	hideCursor = esc + "?25l"
 	showCursor = esc + "?25h"
+	noLineWrap = esc + "\x1b[?7l"
+	doLineWrap = esc + "\x1b[?7h"
 	clearLine  = esc + "2K"
 )
 

--- a/prompt.go
+++ b/prompt.go
@@ -189,7 +189,7 @@ func (p *Prompt) Run() (string, error) {
 	c.SetListener(listen)
 
 	for {
-		_, err := rl.Readline()
+		_, err = rl.Readline()
 		inputErr = validFn(cur.Get())
 		if inputErr == nil {
 			break

--- a/select.go
+++ b/select.go
@@ -235,6 +235,7 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 	}
 
 	rl.Write([]byte(hideCursor))
+	rl.Write([]byte(noLineWrap))
 	sb := screenbuf.New(rl)
 
 	cur := NewCursor("", s.Pointer, false)
@@ -368,11 +369,14 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		if err.Error() == "Interrupt" {
 			err = ErrInterrupt
 		}
+		clearScreen(sb)
 		sb.Reset()
 		sb.WriteString("")
 		sb.Flush()
 		rl.Write([]byte(showCursor))
 		rl.Close()
+
+		os.Stdout.Write([]byte(doLineWrap))
 		return 0, "", err
 	}
 


### PR DESCRIPTION
In pr #86 an err shadowing bug was introduced that prevents `ErrInterrupt` from being passed through to callers. You can see the bug here: 

https://github.com/manifoldco/promptui/pull/86/files#diff-b92032e305aca88aca8d6f3b22e31040L225

Since this change, the `err` check on L243 is no longer reading `err` values (e.g. `ErrInterrupt`) passed through from `rl.Readline()`