### PR TITLE
fix: Interrupt was not catched because err was out of scope

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -189,7 +189,7 @@ func (p *Prompt) Run() (string, error) {
 	c.SetListener(listen)
 
 	for {
-		_, err := rl.Readline()
+		_, err = rl.Readline()
 		inputErr = validFn(cur.Get())
 		if inputErr == nil {
 			break


### PR DESCRIPTION
Closes #102