### PR TITLE
Allow Select to always return when Enter is pressed

### DIFF
--- a/promptui.go
+++ b/promptui.go
@@ -22,6 +22,10 @@ var ErrInterrupt = errors.New("^C")
 // ErrAbort is the error returned when confirm prompts are supplied "n"
 var ErrAbort = errors.New("")
 
+// ErrNotFound is the error returned from prompts when enter is pressed, EnterAlwaysReturns is true and no item
+// is selected
+var ErrNotFound = errors.New("-1")
+
 // ValidateFunc is a placeholder type for any validation functions that validates a given input. It should return
 // a ValidationError if the input is not valid.
 type ValidateFunc func(string) error

--- a/select.go
+++ b/select.go
@@ -70,6 +70,10 @@ type Select struct {
 	// For search mode to work, the Search property must be implemented.
 	StartInSearchMode bool
 
+	// EnterAlwaysReturns sets whether or not pressing enter will always cause the search prompt to return index
+	// NotFound, current user input and error ErrNotFound when no item is selected.
+	EnterAlwaysReturns bool
+
 	label string
 
 	list *list.List
@@ -360,8 +364,12 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		_, idx := s.list.Items()
 		if idx != list.NotFound {
 			break
+		} else if s.EnterAlwaysReturns {
+			clearScreen(sb)
+			rl.Write([]byte(showCursor))
+			rl.Close()
+			return list.NotFound, cur.Get(), ErrNotFound
 		}
-
 	}
 
 	if err != nil {


### PR DESCRIPTION
Add EnterAlwaysReturns to Select which sets whether or not pressing enter will always cause the search prompt to return. When no item is selected, index NotFound and current user input is returned.