### PR TITLE
Set custom stdio for Prompt

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -47,8 +47,8 @@ type Prompt struct {
 	// the Pointer defines how to render the cursor.
 	Pointer Pointer
 
-	stdin  io.ReadCloser
-	stdout io.WriteCloser
+	Stdin  io.ReadCloser
+	Stdout io.WriteCloser
 }
 
 // PromptTemplates allow a prompt to be customized following stdlib
@@ -118,8 +118,8 @@ func (p *Prompt) Run() (string, error) {
 	}
 
 	c := &readline.Config{
-		Stdin:          p.stdin,
-		Stdout:         p.stdout,
+		Stdin:          p.Stdin,
+		Stdout:         p.Stdout,
 		EnableMask:     p.Mask != 0,
 		MaskRune:       p.Mask,
 		HistoryLimit:   -1,


### PR DESCRIPTION
This PR allows `stdin` and `stdout` to be configured for Prompt similar to how it is done in Select #112.
This fixes issue #63. 