### PR TITLE
Add Ctrl-H support to delete input text

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -195,7 +195,7 @@ func (c *Cursor) Listen(line []rune, pos int, key rune) ([]rune, int, bool) {
 	case 0: // empty
 	case KeyEnter:
 		return []rune(c.Get()), c.Position, false
-	case KeyBackspace:
+	case KeyBackspace, KeyCtrlH:
 		if c.erase {
 			c.erase = false
 			c.Replace("")

--- a/keycodes.go
+++ b/keycodes.go
@@ -13,6 +13,9 @@ var (
 	// KeyBackspace is the default key for deleting input text.
 	KeyBackspace rune = readline.CharBackspace
 
+	// KeyCtrlH is the key for deleting input text.
+	KeyCtrlH rune = readline.CharCtrlH
+
 	// KeyPrev is the default key to go up during selection.
 	KeyPrev        rune = readline.CharPrev
 	KeyPrevDisplay      = "↑"

--- a/select.go
+++ b/select.go
@@ -273,7 +273,7 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 			} else {
 				searchMode = true
 			}
-		case key == KeyBackspace:
+		case key == KeyBackspace || key == KeyCtrlH:
 			if !canSearch || !searchMode {
 				break
 			}


### PR DESCRIPTION
Currently, <kbd>Ctrl</kbd>+<kbd>H</kbd> is unavailable to delete input text. It will be good for some users to support <kbd>Ctrl</kbd>+<kbd>H</kbd>.