### PR TITLE
Use the same keycodes cross-platform

### DIFF
--- a/keycodes.go
+++ b/keycodes.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package promptui
 
 import "github.com/chzyer/readline"
@@ -9,9 +7,6 @@ import "github.com/chzyer/readline"
 var (
 	// KeyEnter is the default key for submission/selection.
 	KeyEnter rune = readline.CharEnter
-
-	// KeyBackspace is the default key for deleting input text.
-	KeyBackspace rune = readline.CharBackspace
 
 	// KeyPrev is the default key to go up during selection.
 	KeyPrev        rune = readline.CharPrev

--- a/keycodes_other.go
+++ b/keycodes_other.go
@@ -1,0 +1,10 @@
+// +build !windows
+
+package promptui
+
+import "github.com/chzyer/readline"
+
+var (
+	// KeyBackspace is the default key for deleting input text.
+	KeyBackspace rune = readline.CharBackspace
+)

--- a/keycodes_windows.go
+++ b/keycodes_windows.go
@@ -1,29 +1,10 @@
+// +build windows
+
 package promptui
 
 // source: https://msdn.microsoft.com/en-us/library/aa243025(v=vs.60).aspx
 
 var (
-	// KeyEnter is the default key for submission/selection inside a command line prompt.
-	KeyEnter rune = 13
-
 	// KeyBackspace is the default key for deleting input text inside a command line prompt.
 	KeyBackspace rune = 8
-
-	// FIXME: keys below are not triggered by readline, not working on Windows
-
-	// KeyPrev is the default key to go up during selection inside a command line prompt.
-	KeyPrev        rune = 38
-	KeyPrevDisplay      = "k"
-
-	// KeyNext is the default key to go down during selection inside a command line prompt.
-	KeyNext        rune = 40
-	KeyNextDisplay      = "j"
-
-	// KeyBackward is the default key to page up during selection inside a command line prompt.
-	KeyBackward        rune = 37
-	KeyBackwardDisplay      = "h"
-
-	// KeyForward is the default key to page down during selection inside a command line prompt.
-	KeyForward        rune = 39
-	KeyForwardDisplay      = "l"
 )


### PR DESCRIPTION
Use the same keycodes cross-platform.  Keyboard keys work fine on Windows.