### PR TITLE
Fixes race conditions as mentioned in #148

### DIFF
--- a/select.go
+++ b/select.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"text/template"
 
 	"github.com/chzyer/readline"
@@ -220,6 +221,9 @@ func (s *Select) RunCursorAt(cursorPos, scroll int) (int, string, error) {
 }
 
 func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) {
+	mutex := new(sync.Mutex)
+	closing := false
+
 	c := &readline.Config{
 		Stdin:  s.Stdin,
 		Stdout: s.Stdout,
@@ -254,6 +258,13 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 	s.list.SetStart(scroll)
 
 	c.SetListener(func(line []rune, pos int, key rune) ([]rune, int, bool) {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		if closing {
+			return nil, 0, false
+		}
+
 		switch {
 		case key == KeyEnter:
 			return nil, 0, true
@@ -372,6 +383,10 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		}
 
 	}
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	closing = true
 
 	if err != nil {
 		if err.Error() == "Interrupt" {


### PR DESCRIPTION
This PR resolves the race conditions mentioned in #148.

The race condition was causing rendering glithces with prompts for me, it annoyed me sufficiently that I decided to investigate why the rendering was glitching and wrote a fix. Here's a PR for it if you'd like.

In summary what happens in most cases is when you hit "enter" in a prompt, an "ioloop" goroutine in the readline package dispatches the event to both the listen handler, and to the code that returns from `.Readline()`. Because both the listen handler and the code that occurs after `.Readline()` returns in promptui mutate the readline screen buffer without synchronization, a data race occurs, and can cause rendering glitches depending on the order of execution (not to mention the data race itself is unsafe anyway).

This fix adds a mutex to synchronize the access between the listen handler and the after `.Readline()` return handling, additionally a closing variable is used to indicate to the listen handler when it should stop processing events as the prompt is quitting as to prevent the incorrect final text from being displayed.

I've tested this code on the example provided in #148, and with my own code, and it appears to be functioning great now without any rendering glitches in prompts, nor any warnings from Go's race detector when running with `-race`.

Reminder that after merging and testing, you'll probably want to release this as an update.