### PR TITLE
Don't show error prompt until user inputs something

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -158,18 +158,20 @@ func (p *Prompt) Run() (string, error) {
 	eraseDefault := input != "" && !p.AllowEdit
 	cur := NewCursor(input, p.Pointer, eraseDefault)
 
+	initial := true
 	listen := func(input []rune, pos int, key rune) ([]rune, int, bool) {
 		_, _, keepOn := cur.Listen(input, pos, key)
 		err := validFn(cur.Get())
 		var prompt []byte
 
-		if err != nil {
+		initial = initial && len(input) == 0 && key == 0
+		switch {
+		case initial || p.IsConfirm:
+			prompt = render(p.Templates.prompt, p.Label)
+		case err != nil:
 			prompt = render(p.Templates.invalid, p.Label)
-		} else {
+		case err == nil:
 			prompt = render(p.Templates.valid, p.Label)
-			if p.IsConfirm {
-				prompt = render(p.Templates.prompt, p.Label)
-			}
 		}
 
 		echo := cur.Format()


### PR DESCRIPTION
When a prompt is given a validation function that fails on the empty string,
the user experience of immediately being shown an "X" can be jarring.
Instead track whether the user has ever input something, and if they haven't
render the initial prompt instead.