### PR TITLE
Remove LGPLv3 Dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/chzyer/logex v1.1.10 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e
 	github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 // indirect
-	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect

--- a/select.go
+++ b/select.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"text/tabwriter"
 	"text/template"
 
 	"github.com/chzyer/readline"
-	"github.com/juju/ansiterm"
 	"github.com/manifoldco/promptui/list"
 	"github.com/manifoldco/promptui/screenbuf"
 )
@@ -587,7 +587,8 @@ func (s *Select) renderDetails(item interface{}) [][]byte {
 	}
 
 	var buf bytes.Buffer
-	w := ansiterm.NewTabWriter(&buf, 0, 0, 8, ' ', 0)
+
+	w := tabwriter.NewWriter(&buf, 0, 0, 8, ' ', 0)
 
 	err := s.Templates.details.Execute(w, item)
 	if err != nil {


### PR DESCRIPTION
This PR addresses https://github.com/manifoldco/promptui/issues/173

`promptui` is only using the `ansiterm` library for its `TabWriter`. However, this library is licensed under LGPLv3 https://github.com/juju/ansiterm/blob/master/LICENSE, causing licensing issues for other projects that want to include `promptui`.

This PR changes `promptui` to use Go's built in `TabWriter` rather than the one provided by `ansiterm`. This could result in some loss in features. All tests are passing still after this change, but it would be good for someone more familiar with the library to verify that this does not cause any significant problems.