### PR TITLE
fix: end readline listener immediately if interrupt character is received

### DIFF
--- a/select.go
+++ b/select.go
@@ -288,6 +288,8 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 			s.list.PageUp()
 		case key == s.Keys.PageDown.Code || (key == 'l' && !searchMode):
 			s.list.PageDown()
+		case key == readline.CharInterrupt || key == readline.CharKill:
+			return nil, 0, true
 		default:
 			if canSearch && searchMode {
 				cur.Update(string(line))


### PR DESCRIPTION
this is to fix a bug with select prompts where the prompt is sometimes still flushed to output even though the user has provided the interrupt key (this can cause confusion and looks not-so-pretty)

## before (happens inconsistently):
![image](https://user-images.githubusercontent.com/97612659/223888951-1455428a-08a1-4ff0-880c-2dff0ec66284.png)

## after:
![image](https://user-images.githubusercontent.com/97612659/223888987-9e265589-9f98-4758-bbf2-cdbea9220f38.png)


There might be use cases where you **don't** want to return immediately in this case, so let me know if that's the case!
