### PR TITLE
Fix issue #81: do not return err if 'n' is chosen in confirm prompt

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -58,19 +58,22 @@ type Prompt struct {
 // text/template syntax. Custom state, colors and background color are available for use inside
 // the templates and are documented inside the Variable section of the docs.
 //
-// Examples
+// # Examples
 //
 // text/templates use a special notation to display programmable content. Using the double bracket notation,
 // the value can be printed with specific helper functions. For example
 //
 // This displays the value given to the template as pure, unstylized text.
-// 	'{{ . }}'
+//
+//	'{{ . }}'
 //
 // This displays the value colored in cyan
-// 	'{{ . | cyan }}'
+//
+//	'{{ . | cyan }}'
 //
 // This displays the value colored in red with a cyan background-color
-// 	'{{ . | red | cyan }}'
+//
+//	'{{ . | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 type PromptTemplates struct {
@@ -229,11 +232,13 @@ func (p *Prompt) Run() (string, error) {
 	prompt := render(p.Templates.success, p.Label)
 	prompt = append(prompt, []byte(echo)...)
 
+	lowerDefault := strings.ToLower(p.Default)
 	if p.IsConfirm {
-		lowerDefault := strings.ToLower(p.Default)
-		if strings.ToLower(cur.Get()) != "y" && (lowerDefault != "y" || (lowerDefault == "y" && cur.Get() != "")) {
+		if (cur.Get() == "" && lowerDefault == "") ||
+			(strings.ToLower(cur.Get()) != "y" && strings.ToLower(cur.Get()) != "n" && cur.Get() != "") {
+
 			prompt = render(p.Templates.invalid, p.Label)
-			err = ErrAbort
+			err = ErrInvalidInput
 		}
 	}
 
@@ -248,6 +253,9 @@ func (p *Prompt) Run() (string, error) {
 	rl.Write([]byte(showCursor))
 	rl.Close()
 
+	if lowerDefault != "" && cur.Get() == "" {
+		return lowerDefault, err
+	}
 	return cur.Get(), err
 }
 

--- a/promptui.go
+++ b/promptui.go
@@ -19,8 +19,8 @@ var ErrEOF = errors.New("^D")
 // encountered.
 var ErrInterrupt = errors.New("^C")
 
-// ErrAbort is the error returned when confirm prompts are supplied "n"
-var ErrAbort = errors.New("")
+// ErrInvalidInput is the error returned when confirm prompts are supplied input different from y/n
+var ErrInvalidInput = errors.New("invalid input")
 
 // ValidateFunc is a placeholder type for any validation functions that validates a given input. It should return
 // a ValidationError if the input is not valid.


### PR DESCRIPTION
The 'n' user input should not be considered an error in a yes/no question. Instead, simply return 'y' or 'n' if chosen.
Allow empty string only if default is set and return it. Otherwise return err.