### PR TITLE
Fixed Bug where terminal not closing before moving on.

### DIFF
--- a/select.go
+++ b/select.go
@@ -117,27 +117,24 @@ type Key struct {
 // text/template syntax. Custom state, colors and background color are available for use inside
 // the templates and are documented inside the Variable section of the docs.
 //
-// # Examples
+// Examples
 //
 // text/templates use a special notation to display programmable content. Using the double bracket notation,
 // the value can be printed with specific helper functions. For example
 //
 // This displays the value given to the template as pure, unstylized text. Structs are transformed to string
 // with this notation.
-//
 //	'{{ . }}'
 //
 // This displays the name property of the value colored in cyan
-//
 //	'{{ .Name | cyan }}'
 //
 // This displays the label property of value colored in red with a cyan background-color
-//
 //	'{{ .Label | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 //
-// # Notes
+// Notes
 //
 // Setting any of these templates will remove the icons from the default templates. They must
 // be added back in each of their specific templates. The styles.go constants contains the default icons.
@@ -385,7 +382,6 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		sb.WriteString("")
 		sb.Flush()
 		rl.Write([]byte(showCursor))
-		rl.Write([]byte("test"))
 		rl.Close()
 		return 0, "", err
 	}

--- a/select.go
+++ b/select.go
@@ -124,13 +124,13 @@ type Key struct {
 //
 // This displays the value given to the template as pure, unstylized text. Structs are transformed to string
 // with this notation.
-// '{{ . }}'
+// 	'{{ . }}'
 //
 // This displays the name property of the value colored in cyan
-// '{{ .Name | cyan }}'
+// 	'{{ .Name | cyan }}'
 //
 // This displays the label property of value colored in red with a cyan background-color
-// '{{ .Label | red | cyan }}'
+// 	'{{ .Label | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 //

--- a/select.go
+++ b/select.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"text/tabwriter"
 	"text/template"
+	"time"
 
 	"github.com/chzyer/readline"
 	"github.com/manifoldco/promptui/list"
@@ -116,24 +117,27 @@ type Key struct {
 // text/template syntax. Custom state, colors and background color are available for use inside
 // the templates and are documented inside the Variable section of the docs.
 //
-// Examples
+// # Examples
 //
 // text/templates use a special notation to display programmable content. Using the double bracket notation,
 // the value can be printed with specific helper functions. For example
 //
 // This displays the value given to the template as pure, unstylized text. Structs are transformed to string
 // with this notation.
-// 	'{{ . }}'
+//
+//	'{{ . }}'
 //
 // This displays the name property of the value colored in cyan
-// 	'{{ .Name | cyan }}'
+//
+//	'{{ .Name | cyan }}'
 //
 // This displays the label property of value colored in red with a cyan background-color
-// 	'{{ .Label | red | cyan }}'
+//
+//	'{{ .Label | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 //
-// Notes
+// # Notes
 //
 // Setting any of these templates will remove the icons from the default templates. They must
 // be added back in each of their specific templates. The styles.go constants contains the default icons.
@@ -381,6 +385,7 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 		sb.WriteString("")
 		sb.Flush()
 		rl.Write([]byte(showCursor))
+		rl.Write([]byte("test"))
 		rl.Close()
 		return 0, "", err
 	}
@@ -398,6 +403,7 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 
 	rl.Write([]byte(showCursor))
 	rl.Close()
+	time.Sleep(time.Millisecond * 100)
 
 	return s.list.Index(), fmt.Sprintf("%v", item), err
 }

--- a/select.go
+++ b/select.go
@@ -124,13 +124,13 @@ type Key struct {
 //
 // This displays the value given to the template as pure, unstylized text. Structs are transformed to string
 // with this notation.
-//	'{{ . }}'
+// '{{ . }}'
 //
 // This displays the name property of the value colored in cyan
-//	'{{ .Name | cyan }}'
+// '{{ .Name | cyan }}'
 //
 // This displays the label property of value colored in red with a cyan background-color
-//	'{{ .Label | red | cyan }}'
+// '{{ .Label | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 //


### PR DESCRIPTION
This should fix the following:
https://github.com/manifoldco/promptui/issues/190
https://github.com/manifoldco/promptui/issues/180

This is not a you issue. The library readline has some problems with how they handle their close functionality.

On creation they setup a bunch of io.loops. (Seen in operations.go, std.go, readline.go)
When you call rl.close() it initiates a close on each of those items, but not all of them close in time before the return. (for whatever reason)
Thus causing missed prints to console because the console output is still not released. People have been doing a Println as an alternative, but this would fix it without needing that, and since it's at close and we're dealing with user input it won't cause excessive operation time.