### PR TITLE
Add support for hiding the label

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/manifoldco/promptui
+module github.com/OrangeMourita/promptui
 
 go 1.12
 

--- a/prompt.go
+++ b/prompt.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/OrangeMourita/promptui/screenbuf"
 	"github.com/chzyer/readline"
-	"github.com/manifoldco/promptui/screenbuf"
 )
 
 // Prompt represents a single line text field input with options for validation and input masks.
@@ -58,19 +58,22 @@ type Prompt struct {
 // text/template syntax. Custom state, colors and background color are available for use inside
 // the templates and are documented inside the Variable section of the docs.
 //
-// Examples
+// # Examples
 //
 // text/templates use a special notation to display programmable content. Using the double bracket notation,
 // the value can be printed with specific helper functions. For example
 //
 // This displays the value given to the template as pure, unstylized text.
-// 	'{{ . }}'
+//
+//	'{{ . }}'
 //
 // This displays the value colored in cyan
-// 	'{{ . | cyan }}'
+//
+//	'{{ . | cyan }}'
 //
 // This displays the value colored in red with a cyan background-color
-// 	'{{ . | red | cyan }}'
+//
+//	'{{ . | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 type PromptTemplates struct {

--- a/select.go
+++ b/select.go
@@ -51,7 +51,7 @@ type Select struct {
 	// HideHelp sets whether to hide help information.
 	HideHelp bool
 
-	// HideLabel sets whether to hide the text displayer on top of the list.
+	// HideLabel sets whether to hide the text displayed on top of the list.
 	HideLabel bool
 
 	// HideSelected sets whether to hide the text displayed after an item is successfully selected.
@@ -523,6 +523,9 @@ type SelectWithAdd struct {
 
 	// HideHelp sets whether to hide help information.
 	HideHelp bool
+
+	// HideLabel sets whether to hide the text displayed on top of the list.
+	HideLabel bool
 }
 
 // Run executes the select list. Its displays the label and the list of items, asking the user to chose any
@@ -546,6 +549,7 @@ func (sa *SelectWithAdd) Run() (int, string, error) {
 			Items:     newItems,
 			IsVimMode: sa.IsVimMode,
 			HideHelp:  sa.HideHelp,
+			HideLabel: sa.HideLabel,
 			Size:      5,
 			list:      list,
 			Pointer:   sa.Pointer,

--- a/select.go
+++ b/select.go
@@ -8,9 +8,9 @@ import (
 	"text/tabwriter"
 	"text/template"
 
+	"github.com/OrangeMourita/promptui/list"
+	"github.com/OrangeMourita/promptui/screenbuf"
 	"github.com/chzyer/readline"
-	"github.com/manifoldco/promptui/list"
-	"github.com/manifoldco/promptui/screenbuf"
 )
 
 // SelectedAdd is used internally inside SelectWithAdd when the add option is selected in select mode.

--- a/select.go
+++ b/select.go
@@ -51,6 +51,9 @@ type Select struct {
 	// HideHelp sets whether to hide help information.
 	HideHelp bool
 
+	// HideLabel sets whether to hide the text displayer on top of the list.
+	HideLabel bool
+
 	// HideSelected sets whether to hide the text displayed after an item is successfully selected.
 	HideSelected bool
 
@@ -116,24 +119,27 @@ type Key struct {
 // text/template syntax. Custom state, colors and background color are available for use inside
 // the templates and are documented inside the Variable section of the docs.
 //
-// Examples
+// # Examples
 //
 // text/templates use a special notation to display programmable content. Using the double bracket notation,
 // the value can be printed with specific helper functions. For example
 //
 // This displays the value given to the template as pure, unstylized text. Structs are transformed to string
 // with this notation.
-// 	'{{ . }}'
+//
+//	'{{ . }}'
 //
 // This displays the name property of the value colored in cyan
-// 	'{{ .Name | cyan }}'
+//
+//	'{{ .Name | cyan }}'
 //
 // This displays the label property of value colored in red with a cyan background-color
-// 	'{{ .Label | red | cyan }}'
+//
+//	'{{ .Label | red | cyan }}'
 //
 // See the doc of text/template for more info: https://golang.org/pkg/text/template/
 //
-// Notes
+// # Notes
 //
 // Setting any of these templates will remove the icons from the default templates. They must
 // be added back in each of their specific templates. The styles.go constants contains the default icons.
@@ -303,8 +309,10 @@ func (s *Select) innerRun(cursorPos, scroll int, top rune) (int, string, error) 
 			sb.Write(help)
 		}
 
-		label := render(s.Templates.label, s.Label)
-		sb.Write(label)
+		if !s.HideLabel {
+			label := render(s.Templates.label, s.Label)
+			sb.Write(label)
+		}
 
 		items, idx := s.list.Items()
 		last := len(items) - 1

--- a/select_test.go
+++ b/select_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/manifoldco/promptui/screenbuf"
+	"github.com/OrangeMourita/promptui/screenbuf"
 )
 
 func TestSelectTemplateRender(t *testing.T) {


### PR DESCRIPTION
Adding support for hiding the label of promptui.Select and promptui.SelectWithAdd. Although you could previously assign an empty string or similar to Label, it would always render a new line (which in that case was empty).

![image](https://github.com/user-attachments/assets/97a7bc9e-3533-4ba6-bf3a-3249e9da2ffe)
![image](https://github.com/user-attachments/assets/73b0bc56-2efe-4216-a947-a003428d9caf)
